### PR TITLE
Aplicar tema oscuro al visor de temas

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,7 +1,5 @@
 body {
     font-family: 'Inter', sans-serif;
-    background-color: #FDFBF8;
-    color: #4A4A4A;
 }
 .nav-link {
     transition: all 0.3s ease;

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -4,7 +4,8 @@
     if (!btn) return;
     btn.textContent = isDark ? '☀️' : '🌙';
   }
-  document.addEventListener('DOMContentLoaded', function() {
+
+  function init() {
     var btn = document.getElementById('theme-toggle');
     if (!btn) return;
     setIcon(document.documentElement.classList.contains('dark'));
@@ -13,5 +14,11 @@
       localStorage.theme = isDark ? 'dark' : 'light';
       setIcon(isDark);
     });
-  });
+  }
+
+  if (document.readyState !== 'loading') {
+    init();
+  } else {
+    document.addEventListener('DOMContentLoaded', init);
+  }
 })();

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,17 @@
+(function() {
+  function setIcon(isDark) {
+    var btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+    btn.textContent = isDark ? '☀️' : '🌙';
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    var btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+    setIcon(document.documentElement.classList.contains('dark'));
+    btn.addEventListener('click', function() {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.theme = isDark ? 'dark' : 'light';
+      setIcon(isDark);
+    });
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         </nav>
     </header>
 
-    <button id="theme-toggle" class="fixed top-4 right-4 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded-md">🌙</button>
+    <button id="theme-toggle" class="fixed top-4 right-4 z-50 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded-md">🌙</button>
 
     <main class="container mx-auto p-4 sm:p-6 lg:p-8">
 

--- a/index.html
+++ b/index.html
@@ -5,11 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Curso Interactivo: Estructuras de Datos y Algoritmos en Bioinformática</title>
     <script>
-      if (localStorage.theme === 'dark' ||
-          (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.classList.add('dark');
-      }
       tailwind.config = { darkMode: 'class' };
+      if (localStorage.theme === 'dark') {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Curso Interactivo: Estructuras de Datos y Algoritmos en Bioinformática</title>
     <script>
-      tailwind.config = { darkMode: 'class' };
+      window.tailwind = window.tailwind || {};
+      window.tailwind.config = { darkMode: 'class' };
       if (localStorage.theme === 'dark') {
         document.documentElement.classList.add('dark');
       } else {

--- a/index.html
+++ b/index.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Curso Interactivo: Estructuras de Datos y Algoritmos en Bioinformática</title>
+    <script>
+      if (localStorage.theme === 'dark' ||
+          (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+      tailwind.config = { darkMode: 'class' };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
@@ -11,9 +18,9 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
 </head>
-<body class="antialiased">
+<body class="antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
 
-    <header class="bg-white/80 backdrop-blur-md shadow-sm sticky top-0 z-50">
+    <header class="bg-white/80 dark:bg-gray-800/80 backdrop-blur-md shadow-sm sticky top-0 z-50">
         <nav class="container mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16">
                 <div class="flex-shrink-0">
@@ -36,12 +43,14 @@
         </nav>
     </header>
 
+    <button id="theme-toggle" class="fixed top-4 right-4 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded-md">🌙</button>
+
     <main class="container mx-auto p-4 sm:p-6 lg:p-8">
 
         <section id="inicio" class="module-content min-h-screen text-center flex flex-col justify-center">
-            <h2 class="text-4xl font-bold tracking-tight text-gray-800 sm:text-5xl md:text-6xl">Introducción a Estructuras de Datos y Algoritmos</h2>
-            <p class="mt-6 max-w-3xl mx-auto text-lg text-gray-600">Una guía interactiva para dominar los fundamentos computacionales esenciales en el campo de la bioinformática.</p>
-            <p class="mt-4 max-w-3xl mx-auto text-base text-gray-500">Bienvenido/a. En el campo de la bioinformática, manejamos volúmenes de datos extraordinariamente grandes. La capacidad de procesar, buscar y analizar esta información de manera eficiente es una necesidad fundamental. Este curso interactivo te proporcionará los cimientos para entender cómo organizar datos de forma inteligente y diseñar procedimientos eficientes para resolver problemas complejos.</p>
+            <h2 class="text-4xl font-bold tracking-tight text-gray-800 dark:text-gray-100 sm:text-5xl md:text-6xl">Introducción a Estructuras de Datos y Algoritmos</h2>
+            <p class="mt-6 max-w-3xl mx-auto text-lg text-gray-600 dark:text-gray-300">Una guía interactiva para dominar los fundamentos computacionales esenciales en el campo de la bioinformática.</p>
+            <p class="mt-4 max-w-3xl mx-auto text-base text-gray-500 dark:text-gray-400">Bienvenido/a. En el campo de la bioinformática, manejamos volúmenes de datos extraordinariamente grandes. La capacidad de procesar, buscar y analizar esta información de manera eficiente es una necesidad fundamental. Este curso interactivo te proporcionará los cimientos para entender cómo organizar datos de forma inteligente y diseñar procedimientos eficientes para resolver problemas complejos.</p>
         </section>
 
 
@@ -162,5 +171,6 @@
     <script src="assets/js/ui.js"></script>
     <script src="assets/js/markdownLoader.js"></script>
     <script src="assets/js/main.js"></script>
+    <script src="assets/js/theme.js"></script>
 </body>
 </html>

--- a/viewer.html
+++ b/viewer.html
@@ -5,11 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Material</title>
   <script>
-    if (localStorage.theme === 'dark' ||
-        (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-      document.documentElement.classList.add('dark');
-    }
     tailwind.config = { darkMode: 'class' };
+    if (localStorage.theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/viewer.html
+++ b/viewer.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
 </head>
-<body class="antialiased">
+<body class="antialiased bg-gray-900 text-gray-100">
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
     <div id="content" class="markdown-body"></div>

--- a/viewer.html
+++ b/viewer.html
@@ -4,18 +4,27 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Material</title>
+  <script>
+    if (localStorage.theme === 'dark' ||
+        (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    }
+    tailwind.config = { darkMode: 'class' };
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
 </head>
-<body class="antialiased bg-gray-900 text-gray-100">
+<body class="antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+  <button id="theme-toggle" class="fixed top-4 right-4 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded-md">🌙</button>
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
     <div id="content" class="markdown-body"></div>
   </main>
   <script src="assets/js/markdownLoader.js"></script>
+  <script src="assets/js/theme.js"></script>
   <script>
     const params = new URLSearchParams(window.location.search);
     const file = params.get('file');

--- a/viewer.html
+++ b/viewer.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Material</title>
   <script>
-    tailwind.config = { darkMode: 'class' };
+    window.tailwind = window.tailwind || {};
+    window.tailwind.config = { darkMode: 'class' };
     if (localStorage.theme === 'dark') {
       document.documentElement.classList.add('dark');
     } else {

--- a/viewer.html
+++ b/viewer.html
@@ -18,7 +18,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
 </head>
 <body class="antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-  <button id="theme-toggle" class="fixed top-4 right-4 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded-md">🌙</button>
+  <button id="theme-toggle" class="fixed top-4 right-4 z-50 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded-md">🌙</button>
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
     <div id="content" class="markdown-body"></div>

--- a/visualizacion.html
+++ b/visualizacion.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body class="antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-  <button id="theme-toggle" class="fixed top-4 right-4 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded-md">🌙</button>
+  <button id="theme-toggle" class="fixed top-4 right-4 z-50 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded-md">🌙</button>
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
     <div id="viz-container"></div>

--- a/visualizacion.html
+++ b/visualizacion.html
@@ -4,15 +4,24 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ejemplo interactivo</title>
+  <script>
+    if (localStorage.theme === 'dark' ||
+        (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    }
+    tailwind.config = { darkMode: 'class' };
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
-<body class="antialiased">
+<body class="antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+  <button id="theme-toggle" class="fixed top-4 right-4 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 p-2 rounded-md">🌙</button>
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
     <div id="viz-container"></div>
   </main>
   <script src="assets/js/visualizationLoader.js"></script>
+  <script src="assets/js/theme.js"></script>
 </body>
 </html>

--- a/visualizacion.html
+++ b/visualizacion.html
@@ -5,11 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ejemplo interactivo</title>
   <script>
-    if (localStorage.theme === 'dark' ||
-        (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-      document.documentElement.classList.add('dark');
-    }
     tailwind.config = { darkMode: 'class' };
+    if (localStorage.theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/visualizacion.html
+++ b/visualizacion.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ejemplo interactivo</title>
   <script>
-    tailwind.config = { darkMode: 'class' };
+    window.tailwind = window.tailwind || {};
+    window.tailwind.config = { darkMode: 'class' };
     if (localStorage.theme === 'dark') {
       document.documentElement.classList.add('dark');
     } else {


### PR DESCRIPTION
## Resumen
- Ajusta el visor de markdown para usar fondo y texto en modo oscuro.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab901424b0832bafee2ef49a01caec