### PR TITLE
Habilita estilos oscuros para markdown

### DIFF
--- a/assets/js/markdownLoader.js
+++ b/assets/js/markdownLoader.js
@@ -4,6 +4,7 @@ async function loadMarkdownInto(el, path) {
     const text = await res.text();
     const content = text.replace(/^---[\s\S]*?---/, '');
     el.innerHTML = marked.parse(content);
+    el.classList.add('markdown-body', 'dark:bg-gray-900', 'dark:text-gray-100');
   } catch (err) {
     el.innerHTML = '<p class="text-red-500">Error cargando el contenido.</p>';
   }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-dark.min.css">
 </head>
 <body class="antialiased">
 

--- a/viewer.html
+++ b/viewer.html
@@ -8,12 +8,12 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-dark.min.css">
 </head>
 <body class="antialiased">
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
-    <div id="content" class="markdown-body"></div>
+    <div id="content" class="markdown-body dark:bg-gray-900 dark:text-gray-100"></div>
   </main>
   <script src="assets/js/markdownLoader.js"></script>
   <script>


### PR DESCRIPTION
## Resumen
- Sustituido `github-markdown.min.css` por `github-markdown-dark.min.css` para aplicar tema oscuro.
- Añadidas clases `dark:bg-gray-900` y `dark:text-gray-100` al contenedor de markdown.
- `markdownLoader.js` asegura que los elementos cargados reciban estilos `markdown-body` compatibles con modo oscuro.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab995e08e4832b9129455f80793cc0