### PR TITLE
Add dark mode class to body root

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,32 @@
+(function() {
+  const STORAGE_KEY = 'theme';
+  const root = document.documentElement;
+  const body = document.body || root;
+
+  function applyTheme(theme) {
+    const isDark = theme === 'dark';
+    root.classList.toggle('dark', isDark);
+    body.classList.toggle('dark', isDark);
+    // Force style update
+    void root.offsetWidth;
+  }
+
+  function toggleTheme() {
+    const newTheme = root.classList.contains('dark') ? 'light' : 'dark';
+    applyTheme(newTheme);
+    localStorage.setItem(STORAGE_KEY, newTheme);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      applyTheme(saved);
+    }
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', toggleTheme);
+    }
+  });
+
+  window.toggleTheme = toggleTheme;
+})();

--- a/index.html
+++ b/index.html
@@ -159,6 +159,7 @@
         </section>
 
     </main>
+    <script src="assets/js/theme.js"></script>
     <script src="assets/js/ui.js"></script>
     <script src="assets/js/markdownLoader.js"></script>
     <script src="assets/js/main.js"></script>

--- a/viewer.html
+++ b/viewer.html
@@ -15,6 +15,7 @@
     <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
     <div id="content" class="markdown-body"></div>
   </main>
+  <script src="assets/js/theme.js"></script>
   <script src="assets/js/markdownLoader.js"></script>
   <script>
     const params = new URLSearchParams(window.location.search);

--- a/visualizacion.html
+++ b/visualizacion.html
@@ -13,6 +13,7 @@
     <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
     <div id="viz-container"></div>
   </main>
+  <script src="assets/js/theme.js"></script>
   <script src="assets/js/visualizationLoader.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend theme handling to toggle `dark` on both `html` and `body`
- load new `theme.js` script across pages for consistent dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab99645c48832ba5411902215cb169