### PR TITLE
Enable class-based dark mode across pages

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -7,20 +7,6 @@ window.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    const themeToggle = document.getElementById('theme-toggle');
-    if (themeToggle) {
-        themeToggle.addEventListener('click', () => {
-            document.documentElement.classList.toggle('dark');
-            const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
-            localStorage.setItem('theme', theme);
-        });
-    }
-
-    if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.classList.add('dark');
-    } else {
-        document.documentElement.classList.remove('dark');
-    }
     window.addEventListener('hashchange', () => {
         showModule(window.location.hash || '#inicio');
     });

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -2,11 +2,18 @@
   const STORAGE_KEY = 'theme';
   const root = document.documentElement;
   const body = document.body || root;
+  
+  function updateIcon(isDark) {
+    const btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+    btn.textContent = isDark ? '☀️' : '🌙';
+  }
 
   function applyTheme(theme) {
     const isDark = theme === 'dark';
     root.classList.toggle('dark', isDark);
     body.classList.toggle('dark', isDark);
+    updateIcon(isDark);
     // Force style update
     void root.offsetWidth;
   }
@@ -19,9 +26,8 @@
 
   document.addEventListener('DOMContentLoaded', () => {
     const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) {
-      applyTheme(saved);
-    }
+    const preferred = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    applyTheme(saved || preferred);
     const toggleBtn = document.getElementById('theme-toggle');
     if (toggleBtn) {
       toggleBtn.addEventListener('click', toggleTheme);

--- a/index.html
+++ b/index.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Curso Interactivo: Estructuras de Datos y Algoritmos en Bioinformática</title>
+    <script>
+      window.tailwind = {
+        config: {
+          darkMode: 'class'
+        }
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
                 <div class="flex-shrink-0">
                     <h1 class="text-xl font-bold text-blue-600 dark:text-blue-400">Bioinformática Interactiva</h1>
                 </div>
-                <div class="hidden md:block">
-                    <div class="ml-10 flex items-baseline space-x-4">
+                <div class="flex items-center space-x-4">
+                    <div class="hidden md:flex items-baseline space-x-4">
                         <a href="#inicio" class="nav-link px-3 py-2 rounded-md text-sm font-medium border-b-2 border-transparent text-gray-700 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 hover:border-blue-500 dark:hover:border-blue-400">Inicio</a>
                         <a href="#tema1" class="nav-link px-3 py-2 rounded-md text-sm font-medium border-b-2 border-transparent text-gray-700 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 hover:border-blue-500 dark:hover:border-blue-400">M1: Fundamentos</a>
                         <a href="#tema2" class="nav-link px-3 py-2 rounded-md text-sm font-medium border-b-2 border-transparent text-gray-700 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 hover:border-blue-500 dark:hover:border-blue-400">M2: Listas enlazadas</a>
@@ -37,8 +37,8 @@
                         <a href="#tema6" class="nav-link px-3 py-2 rounded-md text-sm font-medium border-b-2 border-transparent text-gray-700 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 hover:border-blue-500 dark:hover:border-blue-400">M6: Búsqueda</a>
                         <a href="#tema7" class="nav-link px-3 py-2 rounded-md text-sm font-medium border-b-2 border-transparent text-gray-700 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 hover:border-blue-500 dark:hover:border-blue-400">M7: Ordenación</a>
                         <a href="#tema8" class="nav-link px-3 py-2 rounded-md text-sm font-medium border-b-2 border-transparent text-gray-700 dark:text-gray-300 hover:text-blue-500 dark:hover:text-blue-400 hover:border-blue-500 dark:hover:border-blue-400">M8: Bioinformática</a>
-                        <button id="theme-toggle" class="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">🌓</button>
                     </div>
+                    <button id="theme-toggle" class="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700" aria-label="Cambiar tema"></button>
                 </div>
             </div>
         </nav>

--- a/viewer.html
+++ b/viewer.html
@@ -4,16 +4,26 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Material</title>
+  <script>
+    window.tailwind = {
+      config: {
+        darkMode: 'class'
+      }
+    }
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-dark.min.css">
 </head>
-<body class="antialiased">
+<body class="antialiased bg-gray-50 text-gray-700 dark:bg-gray-900 dark:text-gray-100">
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
-    <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
-    <div id="content" class="markdown-body dark:bg-gray-900 dark:text-gray-100"></div>
+    <div class="mb-4 flex justify-between">
+      <a href="index.html" class="text-blue-500 underline">← Volver</a>
+      <button id="theme-toggle" class="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">🌓</button>
+    </div>
+    <div id="content" class="markdown-body"></div>
   </main>
   <script src="assets/js/theme.js"></script>
   <script src="assets/js/markdownLoader.js"></script>

--- a/viewer.html
+++ b/viewer.html
@@ -21,7 +21,7 @@
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4 flex justify-between">
       <a href="index.html" class="text-blue-500 underline">← Volver</a>
-      <button id="theme-toggle" class="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">🌓</button>
+      <button id="theme-toggle" class="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700" aria-label="Cambiar tema"></button>
     </div>
     <div id="content" class="markdown-body"></div>
   </main>

--- a/visualizacion.html
+++ b/visualizacion.html
@@ -4,13 +4,23 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ejemplo interactivo</title>
+  <script>
+    window.tailwind = {
+      config: {
+        darkMode: 'class'
+      }
+    }
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
-<body class="antialiased">
+<body class="antialiased bg-gray-50 text-gray-700 dark:bg-gray-900 dark:text-gray-100">
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
-    <div class="mb-4"><a href="index.html" class="text-blue-500 underline">← Volver</a></div>
+    <div class="mb-4 flex justify-between">
+      <a href="index.html" class="text-blue-500 underline">← Volver</a>
+      <button id="theme-toggle" class="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">🌓</button>
+    </div>
     <div id="viz-container"></div>
   </main>
   <script src="assets/js/theme.js"></script>

--- a/visualizacion.html
+++ b/visualizacion.html
@@ -19,7 +19,7 @@
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4 flex justify-between">
       <a href="index.html" class="text-blue-500 underline">← Volver</a>
-      <button id="theme-toggle" class="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">🌓</button>
+      <button id="theme-toggle" class="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700" aria-label="Cambiar tema"></button>
     </div>
     <div id="viz-container"></div>
   </main>


### PR DESCRIPTION
## Summary
- configure Tailwind to use class-based dark mode
- add theme toggle buttons and consistent styling on viewer and visualization pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab9b9b2648832bb10a1d9666cce2a2