### PR TITLE
Refactor theme styling into CSS

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,5 +1,12 @@
 body {
     font-family: 'Inter', sans-serif;
+    background-color: #f9fafb; /* gray-50 */
+    color: #374151; /* gray-700 */
+}
+
+.dark body {
+    background-color: #111827; /* gray-900 */
+    color: #f3f4f6; /* gray-100 */
 }
 .nav-link {
     transition: all 0.3s ease;
@@ -11,6 +18,15 @@ body {
     border-radius: 0.75rem;
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb; /* gray-200 */
+    color: #374151; /* gray-700 */
+}
+
+.dark .module-card {
+    background-color: #1f2937; /* gray-800 */
+    border-color: #374151; /* gray-700 */
+    color: #f3f4f6; /* gray-100 */
 }
 .module-card:hover {
     transform: translateY(-5px);

--- a/assets/html/viz1.html
+++ b/assets/html/viz1.html
@@ -1,7 +1,7 @@
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6 mb-8">
-  <p class="text-gray-700 dark:text-gray-300">La eficiencia es clave. Un algoritmo ineficiente para buscar un motivo en el genoma humano podría tardar años; uno eficiente, segundos. La <strong>notación Big O</strong> nos permite medir cómo escala un algoritmo al aumentar el tamaño de la entrada, enfocándonos en el peor caso para garantizar el rendimiento.</p>
+<div class="module-card p-6 mb-8">
+  <p>La eficiencia es clave. Un algoritmo ineficiente para buscar un motivo en el genoma humano podría tardar años; uno eficiente, segundos. La <strong>notación Big O</strong> nos permite medir cómo escala un algoritmo al aumentar el tamaño de la entrada, enfocándonos en el peor caso para garantizar el rendimiento.</p>
 </div>
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6">
+<div class="module-card p-6">
   <h3 class="text-xl font-semibold mb-4 text-center">Visualizador de Crecimiento Asintótico</h3>
   <div class="chart-container">
     <canvas id="complexityChart"></canvas>

--- a/assets/html/viz2.html
+++ b/assets/html/viz2.html
@@ -1,9 +1,9 @@
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6 mb-8">
-  <p class="text-gray-700 dark:text-gray-300">Explora estructuras lineales como pilas y colas y sus aplicaciones en bioinformática.</p>
+<div class="module-card p-6 mb-8">
+  <p>Explora estructuras lineales como pilas y colas y sus aplicaciones en bioinformática.</p>
 </div>
 
 <div class="grid md:grid-cols-2 gap-8">
-  <div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6">
+  <div class="module-card p-6">
     <h3 class="text-xl font-semibold mb-4 text-center">Pila (Stack - LIFO)</h3>
     <p class="text-sm text-center text-gray-500 dark:text-gray-400 mb-4">El último en entrar es el primero en salir. Útil para revertir secuencias de ADN.</p>
     <div class="h-64 bg-gray-100 dark:bg-gray-700 rounded-lg flex flex-col-reverse items-center p-2 border" id="stack-container"></div>
@@ -12,7 +12,7 @@
       <button onclick="stackPop()" class="btn bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700 text-white px-4 py-2 rounded-lg">Pop</button>
     </div>
   </div>
-  <div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6">
+  <div class="module-card p-6">
     <h3 class="text-xl font-semibold mb-4 text-center">Cola (Queue - FIFO)</h3>
     <p class="text-sm text-center text-gray-500 dark:text-gray-400 mb-4">El primero en entrar es el primero en salir. Ideal para procesar lecturas de secuenciación.</p>
     <div class="h-64 bg-gray-100 dark:bg-gray-700 rounded-lg flex items-center p-2 border" id="queue-container"></div>

--- a/assets/html/viz3.html
+++ b/assets/html/viz3.html
@@ -1,8 +1,8 @@
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6 mb-8">
-  <p class="text-gray-700 dark:text-gray-300">Descubre diferentes algoritmos de búsqueda y compara su rendimiento.</p>
+<div class="module-card p-6 mb-8">
+  <p>Descubre diferentes algoritmos de búsqueda y compara su rendimiento.</p>
 </div>
 
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6">
+<div class="module-card p-6">
   <h3 class="text-xl font-semibold mb-4 text-center">Comparador de Búsqueda: Lineal vs. Binaria</h3>
   <p class="text-center text-gray-600 dark:text-gray-300 mb-4">La búsqueda binaria requiere datos ordenados, pero es exponencialmente más rápida. Observa la diferencia en el número de pasos.</p>
   <div class="flex justify-center items-center space-x-4 mb-4">

--- a/assets/html/viz4.html
+++ b/assets/html/viz4.html
@@ -1,8 +1,8 @@
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6 mb-8">
-  <p class="text-gray-700 dark:text-gray-300">Aprende cómo diferentes algoritmos de ordenación organizan los datos de manera eficiente.</p>
+<div class="module-card p-6 mb-8">
+  <p>Aprende cómo diferentes algoritmos de ordenación organizan los datos de manera eficiente.</p>
 </div>
 
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6">
+<div class="module-card p-6">
   <h3 class="text-xl font-semibold mb-4 text-center">Visualizador de Algoritmos de Ordenación</h3>
   <p class="text-center text-gray-600 dark:text-gray-300 mb-4">Observa cómo diferentes algoritmos ordenan un conjunto de datos. Los algoritmos <code>O(n log n)</code> son mucho más eficientes que los <code>O(n²)</code> para listas grandes.</p>
   <div class="flex justify-center items-center space-x-4 mb-4">

--- a/assets/html/viz5.html
+++ b/assets/html/viz5.html
@@ -1,8 +1,8 @@
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6 mb-8">
-  <p class="text-gray-700 dark:text-gray-300">Conoce los árboles y cómo modelan relaciones jerárquicas en bioinformática.</p>
+<div class="module-card p-6 mb-8">
+  <p>Conoce los árboles y cómo modelan relaciones jerárquicas en bioinformática.</p>
 </div>
 
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6 text-center">
+<div class="module-card p-6 text-center">
   <h3 class="text-xl font-semibold mb-2">Árbol Binario de Búsqueda (BST)</h3>
   <p class="text-gray-600 dark:text-gray-300 mb-4">Una estructura jerárquica eficiente para búsquedas. En bioinformática, se usan para representar relaciones evolutivas (árboles filogenéticos).</p>
   <div class="flex justify-center items-center space-x-2 mb-4">

--- a/assets/html/viz6.html
+++ b/assets/html/viz6.html
@@ -1,8 +1,8 @@
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6 mb-8">
-  <p class="text-gray-700 dark:text-gray-300">Explora los grafos y cómo recorrerlos mediante algoritmos BFS y DFS.</p>
+<div class="module-card p-6 mb-8">
+  <p>Explora los grafos y cómo recorrerlos mediante algoritmos BFS y DFS.</p>
 </div>
 
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6 text-center">
+<div class="module-card p-6 text-center">
   <h3 class="text-xl font-semibold mb-2">Recorridos de Grafos: BFS vs. DFS</h3>
   <p class="text-gray-600 dark:text-gray-300 mb-4">Los grafos modelan redes complejas como interacciones de proteínas o rutas metabólicas. BFS explora por niveles, mientras que DFS explora en profundidad.</p>
   <div id="graph-container" class="h-80 bg-gray-50 dark:bg-gray-800 rounded-lg border p-4 relative">

--- a/assets/html/viz8.html
+++ b/assets/html/viz8.html
@@ -1,4 +1,4 @@
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6 mb-8">
+<div class="module-card p-6 mb-8">
   <h3 class="text-2xl font-bold mb-4 text-center">Caso práctico: Búsqueda eficiente de motivos de ADN</h3>
   <p class="mb-4">Necesitamos encontrar todas las apariciones de 100 motivos de ADN (de 8 bases) dentro de una secuencia de 1 millón de bases. ¿Cómo lo hacemos eficientemente?</p>
   <div class="grid md:grid-cols-2 gap-8">
@@ -16,9 +16,9 @@
     </div>
   </div>
 </div>
-<div class="module-card bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-100 p-6">
+<div class="module-card p-6">
   <h4 class="text-xl font-semibold mb-4 text-center">Experimenta con un motivo</h4>
-  <p class="mb-4 text-gray-700 dark:text-gray-300">Generamos automáticamente una secuencia de ADN y comparamos el tiempo que tardan una búsqueda ingenua y otra con índice de k-mers.</p>
+  <p class="mb-4">Generamos automáticamente una secuencia de ADN y comparamos el tiempo que tardan una búsqueda ingenua y otra con índice de k-mers.</p>
   <div class="space-y-4">
     <textarea id="bio-seq" class="w-full border p-2 font-mono text-sm" rows="3"></textarea>
     <div class="flex gap-2">

--- a/assets/js/visualizations/sortingVisualizer.js
+++ b/assets/js/visualizations/sortingVisualizer.js
@@ -5,7 +5,13 @@ function resetSort() {
     renderSortArray();
 }
 function renderSortArray() {
-    sortContainer.innerHTML = sortArray.map(val => `<div class="sort-bar" style="height: ${val}%"></div>`).join('');
+    sortContainer.innerHTML = '';
+    sortArray.forEach(val => {
+        const bar = document.createElement('div');
+        bar.className = 'sort-bar';
+        bar.style.height = `${val}%`;
+        sortContainer.appendChild(bar);
+    });
 }
 async function runSort() {
     const algo = document.getElementById('sort-algorithm-selector').value;

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-dark.min.css">
 </head>
-<body class="antialiased bg-gray-50 text-gray-700 dark:bg-gray-900 dark:text-gray-100">
+<body class="antialiased">
 
     <header class="bg-white/80 backdrop-blur-md shadow-sm sticky top-0 z-50 dark:bg-gray-800/80">
         <nav class="container mx-auto px-4 sm:px-6 lg:px-8">

--- a/viewer.html
+++ b/viewer.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-dark.min.css">
 </head>
-<body class="antialiased bg-gray-50 text-gray-700 dark:bg-gray-900 dark:text-gray-100">
+<body class="antialiased">
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4 flex justify-between">
       <a href="index.html" class="text-blue-500 underline">← Volver</a>

--- a/visualizacion.html
+++ b/visualizacion.html
@@ -15,7 +15,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
-<body class="antialiased bg-gray-50 text-gray-700 dark:bg-gray-900 dark:text-gray-100">
+<body class="antialiased">
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4 flex justify-between">
       <a href="index.html" class="text-blue-500 underline">← Volver</a>


### PR DESCRIPTION
## Summary
- centralize body and card colors in CSS for easier dark mode management
- clean up visualization snippets by removing inline style classes
- render sorting bars via DOM elements instead of inline `style` attributes

## Testing
- `npm test`
- `npm start` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_e_68aba1743c30832b9670a5e58a1bbc05