### PR TITLE
fix: improve light mode readability

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,12 +1,5 @@
 body {
     font-family: 'Inter', sans-serif;
-    background-color: #f9fafb; /* gray-50 */
-    color: #374151; /* gray-700 */
-}
-
-.dark body {
-    background-color: #111827; /* gray-900 */
-    color: #f3f4f6; /* gray-100 */
 }
 .nav-link {
     transition: all 0.3s ease;

--- a/assets/js/markdownLoader.js
+++ b/assets/js/markdownLoader.js
@@ -4,7 +4,7 @@ async function loadMarkdownInto(el, path) {
     const text = await res.text();
     const content = text.replace(/^---[\s\S]*?---/, '');
     el.innerHTML = marked.parse(content);
-    el.classList.add('markdown-body', 'dark:bg-gray-900', 'dark:text-gray-100');
+    el.classList.add('markdown-body', 'bg-white', 'text-gray-800', 'dark:bg-gray-900', 'dark:text-gray-100');
   } catch (err) {
     el.innerHTML = '<p class="text-red-500">Error cargando el contenido.</p>';
   }

--- a/assets/js/markdownLoader.js
+++ b/assets/js/markdownLoader.js
@@ -3,8 +3,8 @@ async function loadMarkdownInto(el, path) {
     const res = await fetch(path);
     const text = await res.text();
     const content = text.replace(/^---[\s\S]*?---/, '');
+    el.classList.add('markdown-body');
     el.innerHTML = marked.parse(content);
-    el.classList.add('markdown-body', 'bg-white', 'text-gray-800', 'dark:bg-gray-900', 'dark:text-gray-100');
   } catch (err) {
     el.innerHTML = '<p class="text-red-500">Error cargando el contenido.</p>';
   }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -32,8 +32,7 @@
 
   document.addEventListener('DOMContentLoaded', () => {
     const saved = localStorage.getItem(STORAGE_KEY);
-    const preferred = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    applyTheme(saved || preferred);
+    applyTheme(saved || 'light');
     const toggleBtn = document.getElementById('theme-toggle');
     if (toggleBtn) {
       toggleBtn.addEventListener('click', toggleTheme);

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -13,6 +13,12 @@
     const isDark = theme === 'dark';
     root.classList.toggle('dark', isDark);
     body.classList.toggle('dark', isDark);
+    const mdLink = document.getElementById('markdown-style');
+    if (mdLink) {
+      mdLink.href = isDark
+        ? 'https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-dark.min.css'
+        : 'https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-light.min.css';
+    }
     updateIcon(isDark);
     // Force style update
     void root.offsetWidth;

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <link id="markdown-style" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-light.min.css">
   </head>
-  <body class="antialiased">
+  <body class="antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
 
     <header class="bg-white/80 backdrop-blur-md shadow-sm sticky top-0 z-50 dark:bg-gray-800/80">
         <nav class="container mx-auto px-4 sm:px-6 lg:px-8">

--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/style.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-dark.min.css">
-</head>
-<body class="antialiased">
+    <link id="markdown-style" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-light.min.css">
+  </head>
+  <body class="antialiased">
 
     <header class="bg-white/80 backdrop-blur-md shadow-sm sticky top-0 z-50 dark:bg-gray-800/80">
         <nav class="container mx-auto px-4 sm:px-6 lg:px-8">

--- a/viewer.html
+++ b/viewer.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="assets/css/style.css">
   <link id="markdown-style" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-light.min.css">
 </head>
-<body class="antialiased">
+  <body class="antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4 flex justify-between">
       <a href="index.html" class="text-blue-500 underline">← Volver</a>

--- a/viewer.html
+++ b/viewer.html
@@ -15,7 +15,7 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-dark.min.css">
+  <link id="markdown-style" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css/github-markdown-light.min.css">
 </head>
 <body class="antialiased">
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">

--- a/visualizacion.html
+++ b/visualizacion.html
@@ -15,7 +15,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
-<body class="antialiased">
+  <body class="antialiased bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
   <main class="container mx-auto p-4 sm:p-6 lg:p-8">
     <div class="mb-4 flex justify-between">
       <a href="index.html" class="text-blue-500 underline">← Volver</a>


### PR DESCRIPTION
## Summary
- Ensure markdown styling follows the selected theme
- Make markdown sections readable in light mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba348f730832b99b145a139279e73