### PR TITLE
fix: rewrite markdown image paths

### DIFF
--- a/assets/js/markdownLoader.js
+++ b/assets/js/markdownLoader.js
@@ -5,6 +5,16 @@ async function loadMarkdownInto(el, path) {
     const content = text.replace(/^---[\s\S]*?---/, '');
     el.classList.add('markdown-body');
     el.innerHTML = marked.parse(content);
+
+    const base = path.substring(0, path.lastIndexOf('/') + 1);
+    const baseUrl = new URL(base, window.location.origin + '/');
+    el.querySelectorAll('img').forEach(img => {
+      const src = img.getAttribute('src');
+      if (src && !/^(?:[a-z]+:)?\/\//i.test(src) && !src.startsWith('/')) {
+        const resolved = new URL(src, baseUrl);
+        img.setAttribute('src', resolved.pathname);
+      }
+    });
   } catch (err) {
     el.innerHTML = '<p class="text-red-500">Error cargando el contenido.</p>';
   }


### PR DESCRIPTION
## Summary
- ensure Markdown images resolve correctly by rewriting relative paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aba993f138832b9f47653a23548153